### PR TITLE
Update to r-latest on buster with libnode-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get install -y --no-install-recommends \
 
 RUN locale-gen en_US.UTF-8
 
-ENV PROJ_VERSION=6.2.1
+ARG proj_version=6.2.1
+ENV PROJ_VERSION=$proj_version
 # ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 RUN wget http://download.osgeo.org/proj/proj-${PROJ_VERSION}.tar.gz \
@@ -69,8 +70,9 @@ RUN cd /usr/local/share/proj \
 
 # GDAL:
 
-ENV GDAL_VERSION=3.0.2
-ENV GDAL_VERSION_NAME=3.0.2
+ARG gdal_version=3.0.2
+ENV GDAL_VERSION=$gdal_version
+ENV GDAL_VERSION_NAME=$gdal_version
 
 RUN wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION_NAME}.tar.gz \
   && tar -xf gdal-${GDAL_VERSION_NAME}.tar.gz \
@@ -91,7 +93,8 @@ RUN wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION_NAME
 #  && ldconfig
 
 # GEOS:
-ENV GEOS_VERSION=3.8.0
+ARG geos_version=3.8.0
+ENV GEOS_VERSION=$geos_version
 #
 RUN wget http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2 \
   && bzip2 -d geos-*bz2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/rstudio:3.6.1
+FROM rocker/rstudio:latest
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
@@ -31,7 +31,7 @@ RUN apt-get update \
 	tk-dev
 
 RUN apt-get install -y --no-install-recommends \
-	libv8-3.14-dev \
+	libnode-dev \
 	libjq-dev \
 	libprotobuf-dev \
 	libxml2-dev \


### PR DESCRIPTION
HI @Nowosad.

This updates the Dockerfile to use the latest R (at this time `3.6.2`). The main reason for doing this is that the rocker images for R < `3.6.2` are based on Debian Stretch, while `3.6.2` (and presumably into the future) is based on Debian Buster. The reason this is important (for me at least) is that Stretch is only able to install an old version of `libv8-dev`, the library which drives the [V8](https://github.com/jeroen/V8) R package, whereas Buster has a modern version (`libnode-dev`). When `V8` is built against the old `libv8-dev`, it has reduced functionality,  which impacts my [rmapshaper](https://github.com/ateucher/rmapshaper) package.

If you want the R version to be strict, changing

`FROM rocker/rstudio:latest`  to `FROM rocker/rstudio:3.6.2` would achieve the same results...